### PR TITLE
Master branch: Fix for same in-band ip issue

### DIFF
--- a/ansible/playbooks/advance/playbooks/gui_fabric_creation.yml
+++ b/ansible/playbooks/advance/playbooks/gui_fabric_creation.yml
@@ -24,6 +24,8 @@
         pn_clipassword: "{{ PASSWORD }}"                              # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: "{{ pn_fabric_name }}"                        # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"                 # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"                        # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"                          # List of all leaf switches mentioned under [leaf] grp in hosts file.
         pn_toggle_40g: "{{ pn_toggle_40g }}"                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         pn_inband_ip: "{{ pn_inband_ip }}"                            # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         pn_fabric_network: "{{ pn_fabric_network }}"                  # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/advance/playbooks/pn_test_l2_vrrp.yml
+++ b/ansible/playbooks/advance/playbooks/pn_test_l2_vrrp.yml
@@ -50,6 +50,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'vrrp-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/advance/playbooks/pn_test_l3_vrrp.yml
+++ b/ansible/playbooks/advance/playbooks/pn_test_l3_vrrp.yml
@@ -50,6 +50,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'test-l3-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_dci.yml
+++ b/ansible/playbooks/pn_dci.yml
@@ -24,6 +24,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'ansible_bgp_fabric'           # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
       register: ztp_out              # Variable to hold/register output of the above tasks.
       until: ztp_out.failed != true  # If the above code fails it will retry the code
       retries: 3                     # This is the retries count

--- a/ansible/playbooks/pn_ebgp_wan.yml
+++ b/ansible/playbooks/pn_ebgp_wan.yml
@@ -20,8 +20,9 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'wan_ebgp-fabric'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'wan_ebgp-fabric'              # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['wan'] }}"           # List of all spine switches mentioned under [spine] grp in hosts file.
         pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_initial_ztp.yml
+++ b/ansible/playbooks/pn_initial_ztp.yml
@@ -22,12 +22,14 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'ztp-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
         # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"  # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
         # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
         # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l2_with_ztp_thirdparty.yml
+++ b/ansible/playbooks/pn_l2_with_ztp_thirdparty.yml
@@ -1,6 +1,6 @@
 ---
 
-# Initial ZTP setup for only leaf switches
+# Initial ZTP setup for only spine switches
 - name: Zero Touch Provisioning - Initial setup on spine switches
   hosts: spine
   serial: 1
@@ -16,8 +16,9 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'spine-l2-fabric'               # Name of the fabric to create/join.
+        pn_fabric_name: 'spine-l2-fabric'              # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
@@ -63,6 +64,7 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'leaf-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_l3_vrrp_ebgp.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp.yml
@@ -22,6 +22,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'bgp-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_l3_vrrp_ebgp_json.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp_json.yml
@@ -20,8 +20,10 @@
       pn_initial_ztp_json:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'verizon-bgp-fabric'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'verizon-bgp-fabric'           # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_l3_vrrp_ebgp_thirdparty.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp_thirdparty.yml
@@ -20,9 +20,10 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'ebgp-fabric-leaf'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'ebgp-fabric-leaf'             # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
-        pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
+        pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_l3_vrrp_ebgp_thirdparty_json.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp_thirdparty_json.yml
@@ -20,9 +20,10 @@
       pn_initial_ztp_json:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'verizon-ebgp-fabric-leaf'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'verizon-ebgp-fabric-leaf'     # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
-        pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
+        pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_l3_vrrp_ebgp_withoutfile.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp_withoutfile.yml
@@ -22,6 +22,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'bgp-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_l3_vrrp_ospf.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ospf.yml
@@ -20,8 +20,10 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'ospf-fabric'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'ospf-fabric'                  # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
@@ -168,15 +170,15 @@
         # >>> Ebgp parameters end here
       register: ospf_out                         # Variable to hold/register output of the above tasks.
       until: ospf_out.failed != true             # If the above code fails it will retry the code
-      retries: 3                                # This is the retries count
+      retries: 3                                 # This is the retries count
       delay: 1
-      ignore_errors: yes                        # Flag to indicate if we should ignore errors if any.
+      ignore_errors: yes                         # Flag to indicate if we should ignore errors if any.
 
     - debug:
         var: ospf_out.stdout_lines               # Print stdout_lines of register variable.
 
     - pause:
-        seconds: 2                              # Pause playbook execution for specified amount of time.
+        seconds: 2                               # Pause playbook execution for specified amount of time.
 
 
 # This task is to disable ports using pn_run_cli_commands module from library/ directory.

--- a/ansible/playbooks/pn_l3_vrrp_ospf_thirdparty.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ospf_thirdparty.yml
@@ -20,9 +20,10 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'ospf-fabric-leaf'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'ospf-fabric-leaf'             # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
-        pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
+        pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
@@ -70,8 +71,8 @@
   tasks:
     - name: Configure VRRP L3 setup
       pn_ztp_vrrp_l3_thirdparty:
-        pn_cliusername: "{{ USERNAME }}"  # Cli username (value comes from cli_vault.yml).
-        pn_clipassword: "{{ PASSWORD }}"  # Cli password (value comes from cli_vault.yml).
+        pn_cliusername: "{{ USERNAME }}"        # Cli username (value comes from cli_vault.yml).
+        pn_clipassword: "{{ PASSWORD }}"        # Cli password (value comes from cli_vault.yml).
         pn_leaf_list: "{{ groups['leaf'] }}"    # List of all leaf switches mentioned under [leaf] grp in hosts file.
         pn_csv_data: "{{ lookup('file', '{{ csv_file }}') }}"  # VRRP Layer3 data specified in CSV file.
       register: vrrp_out               # Variable to hold/register output of the above tasks.
@@ -111,7 +112,7 @@
         pn_cidr: '24'                           # Subnet mask required to calculate link IPs for layer3 fabric.
         pn_supernet: '30'                       # Supernet mask required to calculate link IPs for layer3 fabric.
         pn_assign_loopback: True                # Flag to indicate if loopback ips should be assigned to vrouters in layer3 fabric. Default: False.
-        pn_loopback_ip: '109.109.108.0/24'    # Loopback ip value for vrouters in layer3 fabric. Default: 109.109.109.0/24.
+        pn_loopback_ip: '109.109.108.0/24'      # Loopback ip value for vrouters in layer3 fabric. Default: 109.109.109.0/24.
         # pn_bfd: True                          # Flag to indicate if BFD config should be added to vrouter interfaces in case of layer3 fabric. Default: False.
         # pn_bfd_min_rx: 200                    # BFD-MIN-RX value required for adding BFD configuration to vrouter interfaces.
         # pn_bfd_multiplier: 3                  # BFD_MULTIPLIER value required for adding BFD configuration to vrouter interfaces.
@@ -167,15 +168,15 @@
         # >>> Ebgp parameters end here
       register: ospf_out                         # Variable to hold/register output of the above tasks.
       until: ospf_out.failed != true             # If the above code fails it will retry the code
-      retries: 3                                # This is the retries count
+      retries: 3                                 # This is the retries count
       delay: 1
-      ignore_errors: yes                        # Flag to indicate if we should ignore errors if any.
+      ignore_errors: yes                         # Flag to indicate if we should ignore errors if any.
 
     - debug:
         var: ospf_out.stdout_lines               # Print stdout_lines of register variable.
 
     - pause:
-        seconds: 2                              # Pause playbook execution for specified amount of time.
+        seconds: 2                               # Pause playbook execution for specified amount of time.
 
 
 # This task is to disable ports using pn_run_cli_commands module from library/ directory.

--- a/ansible/playbooks/pn_l3_vrrp_ospf_withoutfile.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ospf_withoutfile.yml
@@ -20,8 +20,10 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'ospf-fabric'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'ospf-fabric'                  # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
@@ -158,12 +160,12 @@
         pn_ospf_area_id: '0'                               # Area id to configure for ospf. Default: 0
       register: ospf_out                         # Variable to hold/register output of the above tasks.
       until: ospf_out.failed != true             # If the above code fails it will retry the code
-      retries: 3                                # This is the retries count
+      retries: 3                                 # This is the retries count
       delay: 1
-      ignore_errors: yes                        # Flag to indicate if we should ignore errors if any.
+      ignore_errors: yes                         # Flag to indicate if we should ignore errors if any.
 
     - debug:
         var: ospf_out.stdout_lines               # Print stdout_lines of register variable.
 
     - pause:
-        seconds: 2                              # Pause playbook execution for specified amount of time.
+        seconds: 2                               # Pause playbook execution for specified amount of time.

--- a/ansible/playbooks/pn_l3_ztp_thirdparty.yml
+++ b/ansible/playbooks/pn_l3_ztp_thirdparty.yml
@@ -20,9 +20,10 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'ztp-fabric-leaf'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'ztp-fabric-leaf'              # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
-        pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
+        pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/pn_vrrp_l2_with_csv.yml
+++ b/ansible/playbooks/pn_vrrp_l2_with_csv.yml
@@ -20,14 +20,16 @@
       pn_initial_ztp:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'vrrp-l2-fabric'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'vrrp-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
         # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_default_ipv4.address }}"  # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
         # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
         # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_vrrp_l2_with_csv_json.yml
+++ b/ansible/playbooks/pn_vrrp_l2_with_csv_json.yml
@@ -22,12 +22,14 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'ztp-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
         # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_default_ipv4.address }}"  # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
         # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
         # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_vrrp_l3_bfd.yml
+++ b/ansible/playbooks/pn_vrrp_l3_bfd.yml
@@ -22,6 +22,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'bgp-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
@@ -70,8 +72,8 @@
   tasks:
     - name: Configure VRRP L3 setup
       pn_ztp_vrrp_l3:
-        pn_cliusername: "{{ USERNAME }}"  # Cli username (value comes from cli_vault.yml).
-        pn_clipassword: "{{ PASSWORD }}"  # Cli password (value comes from cli_vault.yml).
+        pn_cliusername: "{{ USERNAME }}"        # Cli username (value comes from cli_vault.yml).
+        pn_clipassword: "{{ PASSWORD }}"        # Cli password (value comes from cli_vault.yml).
         pn_spine_list: "{{ groups['spine'] }}"  # List of all spine switches mentioned under [spine] grp in hosts file.
         pn_leaf_list: "{{ groups['leaf'] }}"    # List of all leaf switches mentioned under [leaf] grp in hosts file.
         pn_csv_data: "{{ lookup('file', '{{ csv_file }}') }}"  # VRRP Layer3 data specified in CSV file.

--- a/ansible/playbooks/pn_vxlan.yml
+++ b/ansible/playbooks/pn_vxlan.yml
@@ -22,6 +22,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'bgp-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
@@ -194,18 +196,18 @@
   tasks:
     - name: Configure VXLAN between leaf switches
       pn_vxlan:
-        pn_cliusername: "{{ USERNAME }}"  # Cli username (value comes from cli_vault.yml).
-        pn_clipassword: "{{ PASSWORD }}"  # Cli password (value comes from cli_vault.yml).
+        pn_cliusername: "{{ USERNAME }}"        # Cli username (value comes from cli_vault.yml).
+        pn_clipassword: "{{ PASSWORD }}"        # Cli password (value comes from cli_vault.yml).
         pn_leaf_list: "{{ groups['leaf'] }}"    # List of all leaf switches mentioned under [leaf] grp in hosts file.
         pn_csv_data: "{{ lookup('file', '{{ csv_file }}') }}"  # VRRP Layer3 data specified in CSV file.
-      register: vxlan_out               # Variable to hold/register output of the above tasks.
-      until:  vxlan_out.failed != true  # If error pops up it will retry the code
-      retries: 3                       # This is the retries count
+      register: vxlan_out                       # Variable to hold/register output of the above tasks.
+      until:  vxlan_out.failed != true          # If error pops up it will retry the code
+      retries: 3                                # This is the retries count
       delay: 1
-      ignore_errors: yes               # Flag to indicate if we should ignore errors if any.
+      ignore_errors: yes                        # Flag to indicate if we should ignore errors if any.
 
     - debug:
-        var: vxlan_out.stdout_lines     # Print stdout_lines of register variable.
+        var: vxlan_out.stdout_lines             # Print stdout_lines of register variable.
 
     - pause:
-        seconds: 2                     # Pause playbook execution for specified amount of time.
+        seconds: 2                              # Pause playbook execution for specified amount of time.

--- a/ansible/playbooks/tests/pn_test_l2_vrrp.yml
+++ b/ansible/playbooks/tests/pn_test_l2_vrrp.yml
@@ -53,6 +53,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'vrrp-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/tests/pn_test_l2_ztp_third_party.yml
+++ b/ansible/playbooks/tests/pn_test_l2_ztp_third_party.yml
@@ -50,6 +50,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'test-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
@@ -126,6 +128,7 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'leaf-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/tests/pn_test_l3_vrrp.yml
+++ b/ansible/playbooks/tests/pn_test_l3_vrrp.yml
@@ -51,8 +51,10 @@
       pn_initial_ztp_json:
         pn_cliusername: "{{ USERNAME }}"               # Cli username (value comes from cli_vault.yml).
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
-        pn_fabric_name: 'test-l3-fabric'                   # Name of the fabric to create/join.
+        pn_fabric_name: 'test-l3-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/tests/pn_test_l3_vrrp_third_party.yml
+++ b/ansible/playbooks/tests/pn_test_l3_vrrp_third_party.yml
@@ -57,6 +57,7 @@
         pn_fabric_name: 'test-vrrp-third-party'        # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
         pn_toggle_40g: True                            # Flag to indicate if 40g ports should be converted to 10g ports or not.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/tests/pn_test_ztp_l2.yml
+++ b/ansible/playbooks/tests/pn_test_ztp_l2.yml
@@ -53,6 +53,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'test-l2-fabric'               # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt

--- a/ansible/playbooks/tests/pn_test_ztp_l3.yml
+++ b/ansible/playbooks/tests/pn_test_ztp_l3.yml
@@ -53,6 +53,8 @@
         pn_clipassword: "{{ PASSWORD }}"               # Cli password (value comes from cli_vault.yml).
         pn_fabric_name: 'test-l3-fabric'                   # Name of the fabric to create/join.
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
+        pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
+        pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
         # pn_toggle_40g: True                          # Flag to indicate if 40g ports should be converted to 10g ports or not.
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt


### PR DESCRIPTION
This commit/PR contains:
- Fix for same in-band ip getting assigned to multiple switches
- Improvements to `pn_initial_ztp_json.py` module so that it is compliant with PEP8
- Updates to all playbooks which uses `pn_initial_ztp.py` and `pn_initial_ztp_json.py` modules, since this fix has been made in these 2 modules