### PR TITLE
Made static switch setup default to True

### DIFF
--- a/ansible/playbooks/pn_dci.yml
+++ b/ansible/playbooks/pn_dci.yml
@@ -26,6 +26,9 @@
         pn_current_switch: "{{ inventory_hostname }}"  # Name of the switch on which this task is currently getting executed.
         pn_spine_list: "{{ groups['spine'] }}"         # List of all spine switches mentioned under [spine] grp in hosts file.
         pn_leaf_list: "{{ groups['leaf'] }}"           # List of all leaf switches mentioned under [leaf] grp in hosts file.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
       register: ztp_out              # Variable to hold/register output of the above tasks.
       until: ztp_out.failed != true  # If the above code fails it will retry the code
       retries: 3                     # This is the retries count

--- a/ansible/playbooks/pn_ebgp_wan.yml
+++ b/ansible/playbooks/pn_ebgp_wan.yml
@@ -27,10 +27,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_initial_ztp.yml
+++ b/ansible/playbooks/pn_initial_ztp.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l2_with_ztp_thirdparty.yml
+++ b/ansible/playbooks/pn_l2_with_ztp_thirdparty.yml
@@ -23,10 +23,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.
@@ -69,10 +69,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_vrrp_ebgp.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_vrrp_ebgp_thirdparty.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp_thirdparty.yml
@@ -27,10 +27,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_vrrp_ebgp_withoutfile.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ebgp_withoutfile.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_vrrp_ospf.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ospf.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_vrrp_ospf_thirdparty.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ospf_thirdparty.yml
@@ -27,10 +27,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_vrrp_ospf_withoutfile.yml
+++ b/ansible/playbooks/pn_l3_vrrp_ospf_withoutfile.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_l3_ztp_thirdparty.yml
+++ b/ansible/playbooks/pn_l3_ztp_thirdparty.yml
@@ -27,10 +27,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_vrrp_l2_with_csv.yml
+++ b/ansible/playbooks/pn_vrrp_l2_with_csv.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_vrrp_l3_bfd.yml
+++ b/ansible/playbooks/pn_vrrp_l3_bfd.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/pn_vxlan.yml
+++ b/ansible/playbooks/pn_vxlan.yml
@@ -28,10 +28,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.

--- a/ansible/playbooks/tests/pn_test_l2_ztp_third_party.yml
+++ b/ansible/playbooks/tests/pn_test_l2_ztp_third_party.yml
@@ -56,10 +56,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.
@@ -133,10 +133,10 @@
         # pn_inband_ip: '172.16.1.0/24'                # Inband ips to be assigned to switches starting with this value. Default: 172.16.0.0/24.
         # pn_fabric_network: 'mgmt'                    # Choices: in-band or mgmt.  Default: mgmt
         # pn_fabric_control_network: 'mgmt'            # Choices: in-band or mgmt.  Default: mgmt
-        # pn_static_setup: False                       # Flag to indicate if static values should be assign to following switch setup params. Default: True.
-        # pn_mgmt_ip: "{{ ansible_host }}"             # Specify MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_mgmt_ip_subnet: '16'                      # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
-        # pn_gateway_ip: '10.9.9.0'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
+        pn_static_setup: True                          # Flag to indicate if static values should be assign to following switch setup params. Default: True.
+        pn_mgmt_ip: "{{ ansible_host }}"               # Specify MGMT-IP value to be assign if pn_static_setup is True.
+        pn_mgmt_ip_subnet: '16'                        # Specify subnet mask for MGMT-IP value to be assign if pn_static_setup is True.
+        # pn_gateway_ip: '10.9.9.1'                    # Specify GATEWAY-IP value to be assign if pn_static_setup is True.
         # pn_dns_ip: '10.20.41.1'                      # Specify DNS-IP value to be assign if pn_static_setup is True.
         # pn_dns_secondary_ip: '10.20.4.1'             # Specify DNS-SECONDARY-IP value to be assign if pn_static_setup is True.
         # pn_domain_name: 'pluribusnetworks.com'       # Specify DOMAIN-NAME value to be assign if pn_static_setup is True.


### PR DESCRIPTION
- Default value of `pn_static_setup` flag is True now
- `mgmt-ip` with subnet will always be provided through playbooks
- Updated all playbooks accordingly