### PR TITLE
Added design docs for initial_ztp and l2_ztp modules

### DIFF
--- a/docs/design_docs/pn_initial_ztp.txt
+++ b/docs/design_docs/pn_initial_ztp.txt
@@ -80,9 +80,15 @@ Output msg: 'STP enabled'
 Output/Return:
 This module return following fields in JSON format.
 1. summary: Contains output of each configuration/commands along with switch name on which it got executed. In case of failure, this will contain a message, 'Operation failed: %s', with failed command replacing %s.
-2. changed: Indicates whether the CLI caused changes on switches.
-3. unreachable: Indicates whether switch was unreachable to connect.
-4. failed: Indicates whether the execution of commands failed on switches.
+2. changed: Indicates whether the CLI caused changes on switches, using True/False.
+3. unreachable: Indicates whether switch was unreachable to connect, using True/False.
+4. failed: Indicates whether the execution of commands failed on switches, using True/False.
 5. exception: Describe error/exception occurred during execution of commands.
-6. task: Name of the task getting executed on switches.
-7. msg: Indicates whether configuration made was successful or failed.
+6. task: 'Accept EULA, Disable STP, Enable ports and Create/join fabric'
+7. msg: On success: 'Fabric creation succeeded'
+On failure: 'Fabric creation failed'
+On ssh connection error: 'Failed to connect to host via ssh: ssh: connect to host %s port 22: No route to host' (Note: %s will get replaced by the mgmt ip of unreachable switch)
+On exception failure: 'Unexpected failure during module execution'
+On incorrect login credentials: 'MODULE FAILURE'
+
+Note: On success, summary field is of primary importance, as it shows what configuration has happened on each switch and on failure, msg field provides exact details on why it failed.

--- a/docs/design_docs/pn_initial_ztp.txt
+++ b/docs/design_docs/pn_initial_ztp.txt
@@ -1,0 +1,88 @@
+Module Name: pn_initial_ztp
+
+Description: 
+Module to perform zero touch provisioning (ZTP) on new switches. Zero touch provisioning allows you to provision new switches in your network automatically, without manual intervention. This initial ztp module creates and set up a fabric across your network topology (on all switches).
+
+Input: 
+User provides following inputs to this module.
+1. pn_cliusername: Username to use to login into cli.
+2. pn_clipassword: Password to use for above username to login into cli.
+3. pn_fabric_name: Name of the fabric to create.
+4. pn_fabric_network: Fabric network type. Choices=[mgmt, in-band]. Default=mgmt.
+5. pn_fabric_control_network: Control network type. Choices=[mgmt, in-band]. Default=mgmt.
+6. pn_toggle_40g: Flag to decide if 40g ports should be converted to 10g ports. Default=True
+7. pn_spine_list: List of spine switches.
+8. pn_leaf_list: List of leaf switches.
+9. pn_inband_ip: In-band ip to be assigned to switches starting from this ip. Default=172.16.0.0/24
+10. pn_current_switch: Name of the current switch on which this module is getting executed.
+11. pn_static_setup: Flag to decide if static values should be set to the switch setup. Default: False.
+12. pn_mgmt_ip: Mgmt ip value for static switch setup.
+13. pn_mgmt_ip_subnet: Subnet for the above mgmt ip.
+14. pn_gateway_ip: Gateway ip value for static switch setup.
+15. pn_dns_ip: Dns ip value for static switch setup.
+16. pn_domain_name: Domain name value for static switch setup.
+17. pn_ntp_server: Ntp server value for static switch setup.
+18. pn_web_api: Flag to enable web api. Default: True.
+19. pn_stp: Flag to decide if stp (spanning tree protocol) should be enabled at the end. Default=False.
+
+Steps/Commands: 
+ZTP performs following steps on each new switch.
+(Note: %s values in below commands get substituted with appropriate values provided by the user.)
+
+1. Accept EULA (End User License Agreement)
+/usr/bin/cli --quiet --skip-setup --script-password switch-setup-modify password %s eula-accepted true
+Output msg: 'EULA accepted'
+
+2. Update switch name
+switch-setup-modify switch-name %s
+
+3. Make switch setup static if pn_static_setup flag is True
+switch-setup-modify mgmt-ip %s gateway-ip %s dns-ip %s dns-secondary-ip %s domain-name %s ntp-server %s
+
+4. Create/join fabric
+First switch will create (and join) the fabric using: 
+fabric-create name %s fabric-network %s
+Subsequent switches join the above created fabric using: 
+fabric-join name %s
+Output msg: 'Joined fabric %s'
+
+5. Configure control network to mgmt/in-band
+fabric-local-modify control-network %s
+Output msg: 'Configured fabric control network to %s'
+
+6. Enable web api if pn_web_api flag is True
+admin-service-modify web if mgmt
+
+7. Disable STP
+Disable spanning tree protocol so that ports that are disabled by STP, to prevent loops in network, are visiable and can be configured.
+switch-local stp-modify disable
+Output msg: 'STP disabled'
+
+8. Enable all ports
+swich-local port-config-modify port %s enable
+Output msg: 'Ports enabled'
+
+9. Toggle 40g ports to 10g if pn_toggle_40g flag is True
+One 40g port fanned out to four 10g ports. So to utilize all ports, convert/toggle 40g ports to 10g ports.
+switch-local port-config-modify port %s speed 10g
+Output msg: 'Toggled 40G ports to 10G'
+
+10. Assign in-band ip
+switch-local switch-setup-modify in-band-ip %s
+Output msg: 'Assigned in-band ip %s'
+
+11. Enable STP if pn_stp flag is True
+Enable spanning tree protocol to prevent loops in network.
+If pn_stp flag is True then and only then run: 
+switch-local stp-modify enable
+Output msg: 'STP enabled'
+
+Output/Return:
+This module return following fields in JSON format.
+1. summary: Contains output of each configuration/commands along with switch name on which it got executed. In case of failure, this will contain a message, 'Operation failed: %s', with failed command replacing %s.
+2. changed: Indicates whether the CLI caused changes on switches.
+3. unreachable: Indicates whether switch was unreachable to connect.
+4. failed: Indicates whether the execution of commands failed on switches.
+5. exception: Describe error/exception occurred during execution of commands.
+6. task: Name of the task getting executed on switches.
+7. msg: Indicates whether configuration made was successful or failed.

--- a/docs/design_docs/pn_l2_ztp.txt
+++ b/docs/design_docs/pn_l2_ztp.txt
@@ -1,0 +1,88 @@
+Module Name: pn_l2_ztp
+
+Description: 
+This module is extension of pn_initial_ztp module to configure vLags for Layer2 fabric. This module will create spine cluster and clusters between leafs which are physically connected to each other, followed by required trunk and vlag creations. 
+
+Input: 
+User provides following inputs to this module.
+1. pn_cliusername: Username to use to login into cli.
+2. pn_clipassword: Password to use for above username to login into cli.
+3. pn_spine_list: List of spine switches.
+4. pn_leaf_list: List of leaf switches.
+5. pn_update_fabric_to_inband: Flag to indicate if fabric network should be updated to in-band. Default=False. 
+6. pn_stp: Flag to decide if stp (spanning tree protocol) should be enabled at the end. Default=False.
+
+Steps/Commands: 
+This module performs following steps.
+(Note: %s values in below commands get substituted with appropriate values provided by the user.)
+
+1. Create a cluster between two spine switches
+cluster-create name %s cluster-node-1 %s cluster-node-2 %s
+Output msg: 'Created %s' 
+
+2. Create clusters between physically connected leaf switches
+cluster-create name %s cluster-node-1 %s cluster-node-2 %s
+Note: A switch can be part of one and only one cluster. If leaf1 is connected to leaf2 and leaf3, and if we form the cluster between leaf1 and leaf2, then we cannot form cluster between leaf1 and leaf3, even though they are physically connected.
+Output msg: 'Created %s'
+
+3. Get the list of ports that are connected from clustered leaf to spine switches
+port-show hostname %s format port no-show-headers
+
+4. Create trunk from clustered leaf to spine switches using above ports
+trunk-create name %s ports %s
+Output msg: 'Created trunk %s'
+
+5. Configure vLag from clustered leaf to spine switches
+vlag-create name %s port %s peer-switch %s peer-port %s mode active-active
+Output msg: 'Configured vLag %s'
+
+6. Get the list of ports that are connected from spine to clustered leaf switches
+port-show hostname %s format port no-show-headers
+
+7. Create trunk from spine to clustered leaf switches using above ports
+trunk-create name %s ports %s
+Output msg: 'Created trunk %s'
+
+8. Configure vLag from spine to clustered leaf switches
+vlag-create name %s port %s peer-switch %s peer-port %s mode active-active
+Output msg: 'Configured vLag %s'
+
+9. Find leaf switches that are not part of any cluster (non-clustered leaf switches)
+First get the list of leaf switches that are part of clusters using: cluster-show format cluster-node-1,cluster-node-2 no-show-headers
+Now, using pn_leaf_list, check which all leaf switches are not part of the above cluster switches list and create a list of non-clustered leaf switches from this.
+
+10. Get the list of ports that are connected from non-clustered leaf to spine switches
+port-show hostname %s format port no-show-headers
+
+11. Create trunk from non-clustered leaf to spine switches using above ports
+trunk-create name %s ports %s
+Output msg: 'Created trunk %s'
+
+11. Get the list of ports that are connected from spine to non-clustered leaf switches
+port-show hostname %s format port no-show-headers
+
+12. Create trunk from spine to non-clustered leaf switches using above ports
+trunk-create name %s ports %s
+Output msg: 'Created trunk %s'
+
+13. Configure vLag from spine to non-clustered leaf switches
+vlag-create name %s port %s peer-switch %s peer-port %s mode active-active
+Output msg: 'Configured vLag %s'
+
+14. Update fabric network to in-band for all switches if pn_update_fabric_to_inband flag is True
+fabric-local-modify fabric-network in-band
+Output msg: 'Updated fabric network to in-band'
+
+15. Enable STP (spanning tree protocol) on all switches if pn_stp flag is True
+stp-modify enable
+Output msg: 'STP enabled'
+
+Output/Return:
+This module return following fields in JSON format.
+1. summary: Contains output of each configuration/commands along with switch name on which it got executed. In case of failure, this will contain a message, 'Operation failed: %s', with failed command replacing %s.
+2. changed: Indicates whether the CLI caused changes on switches.
+3. unreachable: Indicates whether switch was unreachable to connect.
+4. failed: Indicates whether the execution of commands failed on switches.
+5. exception: Describe error/exception occurred during execution of commands.
+6. task: Name of the task getting executed on switches.
+7. msg: Indicates whether configuration made was successful or failed.

--- a/docs/design_docs/pn_l2_ztp.txt
+++ b/docs/design_docs/pn_l2_ztp.txt
@@ -80,9 +80,15 @@ Output msg: 'STP enabled'
 Output/Return:
 This module return following fields in JSON format.
 1. summary: Contains output of each configuration/commands along with switch name on which it got executed. In case of failure, this will contain a message, 'Operation failed: %s', with failed command replacing %s.
-2. changed: Indicates whether the CLI caused changes on switches.
-3. unreachable: Indicates whether switch was unreachable to connect.
-4. failed: Indicates whether the execution of commands failed on switches.
+2. changed: Indicates whether the CLI caused changes on switches, using True/False.
+3. unreachable: Indicates whether switch was unreachable to connect, using True/False.
+4. failed: Indicates whether the execution of commands failed on switches, using True/False.
 5. exception: Describe error/exception occurred during execution of commands.
-6. task: Name of the task getting executed on switches.
-7. msg: Indicates whether configuration made was successful or failed.
+6. task: 'Configure L2 ZTP (Auto vLags)'
+7. msg: On success: 'L2 ZTP configuration succeeded'
+On failure: 'L2 ZTP configuration failed'
+On ssh connection error: 'Failed to connect to host via ssh: ssh: connect to host %s port 22: No route to host' (Note: %s will get replaced by the mgmt ip of unreachable switch)
+On exception failure: 'Unexpected failure during module execution'
+On incorrect login credentials: 'MODULE FAILURE'
+
+Note: On success, summary field is of primary importance, as it shows what configuration has happened on each switch and on failure, msg field provides exact details on why it failed.


### PR DESCRIPTION
Created `design_docs` directory under `docs/` directory to store all 1 pager design notes.
Added design notes for `pn_initial_ztp` and `pn_l2_ztp` modules.