### PR TITLE
added length checking to avoid cli errors

### DIFF
--- a/ansible/library/pn_l2_third_party.py
+++ b/ansible/library/pn_l2_third_party.py
@@ -376,9 +376,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                 node2 = system_names[node_count]
                 if node2 in non_clustered_leafs:
                     # Cluster creation
-                    cluster_name = node1 + '-to-' + node2 + '-cluster'
-                    if len(cluster_name) > 59:
-                        cluster_name = cluster_name[:59]
+                    cluster_name = (node1 + '-to-' + node2 + '-cluster')[:59]
 
                     output += create_cluster(module, node2, cluster_name,
                                              node1, node2)
@@ -394,9 +392,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                     output += trunk_message2[0] + '\n'
 
                     # Vlag creation (leaf to spine)
-                    vlag_name = node1 + '-' + node2 + '-to-' + 'spine'
-                    if len(vlag_name) > 59:
-                        vlag_name = vlag_name[:59]
+                    vlag_name = (node1 + '-' + node2 + '-to-' + 'spine')[:59]
 
                     output += create_vlag(module, node1, vlag_name, node2,
                                           trunk_name1, trunk_name2)

--- a/ansible/library/pn_l2_ztp.py
+++ b/ansible/library/pn_l2_ztp.py
@@ -295,9 +295,7 @@ def configure_trunk(module, cluster_node, switch_list):
         switch_names += str(switch)
 
     src_ports = list(set(src_ports))
-    name = cluster_node + '-to-' + switch_names
-    if len(name) > 59:
-        name = name[:59]
+    name = (cluster_node + '-to-' + switch_names)[:59]
 
     output = create_trunk(module, cluster_node, name, src_ports)
 
@@ -347,9 +345,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                 node2 = system_names[node_count]
                 if node2 in non_clustered_leafs:
                     # Cluster creation
-                    cluster_name = node1 + '-to-' + node2 + '-cluster'
-                    if len(cluster_name) > 59:
-                        cluster_name = cluster_name[:59]
+                    cluster_name = (node1 + '-to-' + node2 + '-cluster')[:59]
 
                     output += create_cluster(module, node2, cluster_name,
                                              node1, node2)
@@ -364,9 +360,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                     output += trunk_message1[0] + '\n'
                     output += trunk_message2[0] + '\n'
                     # Vlag creation (leaf to spines)
-                    vlag_name = node1 + '-' + node2 + '-to-' + 'spine'
-                    if len(vlag_name) > 59:
-                        vlag_name = vlag_name[:59]
+                    vlag_name = (node1 + '-' + node2 + '-to-' + 'spine')[:59]
 
                     output += create_vlag(module, node1, vlag_name, node2,
                                           trunk_name1, trunk_name2)
@@ -384,9 +378,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                     output += trunk_message2[0] + '\n'
 
                     # Vlag creation (spine to leafs)
-                    name =  'spine-to-' + node1 + '-' + node2
-                    if len(name) > 59:
-                        name = name[:59]
+                    name =  ('spine-to-' + node1 + '-' + node2)[:59]
 
                     output += create_vlag(module, spine1, name, spine2,
                                           trunk_name1, trunk_name2)
@@ -424,9 +416,7 @@ def configure_trunk_non_clustered_leafs(module, non_clustered_leafs,
         output += trunk_message2[0] + '\n'
 
         # Vlag creation (spine to leafs)
-        name = 'spine-to-' + leaf
-        if len(name) > 59:
-            name = name[:59]
+        name = ('spine-to-' + leaf)[:59]
 
         output += create_vlag(module, spine1, name, spine2, trunk_name1,
                               trunk_name2)

--- a/ansible/library/pn_l2_ztp_additional_switches.py
+++ b/ansible/library/pn_l2_ztp_additional_switches.py
@@ -286,9 +286,7 @@ def configure_trunk(module, cluster_node, switch_list):
         switch_names += str(switch)
 
     src_ports = list(set(src_ports))
-    name = cluster_node + '-to-' + switch_names
-    if len(name) > 59:
-        name = name[:59]
+    name = (cluster_node + '-to-' + switch_names)[:59]
 
     output = create_trunk(module, cluster_node, name, src_ports)
 
@@ -355,9 +353,7 @@ def configure_trunk_vlag_for_clustered_leafs(module):
                     output += trunk_message2[0]
 
                     # Vlag creation (leaf to spines)
-                    vlag_name = node1 + '-' + node2 + '-to-' + 'spine'
-                    if len(vlag_name) > 59:
-                        vlag_name = vlag_name[:59]
+                    vlag_name = (node1 + '-' + node2 + '-to-' + 'spine')[:59]
 
                     output += create_vlag(module, node1, vlag_name, node2,
                                           trunk_name1, trunk_name2)
@@ -375,9 +371,7 @@ def configure_trunk_vlag_for_clustered_leafs(module):
                     output += trunk_message2[0]
 
                     # Vlag creation (spine to leafs)
-                    name = 'spine-to-' + node1 + '-' + node2
-                    if len(name) > 59:
-                        name = name[:59]
+                    name = ('spine-to-' + node1 + '-' + node2)[:59]
 
                     output += create_vlag(module, spine1, name, spine2,
                                           trunk_name1, trunk_name2)
@@ -414,9 +408,7 @@ def configure_trunk_non_clustered_leafs(module, non_clustered_leafs):
         output += trunk_message2[0]
 
         # Vlag creation (spine to leafs)
-        name = 'spine-to-' + leaf
-        if len(name) > 59:
-            name = name[:59]
+        name = ('spine-to-' + leaf)[:59]
 
         output += create_vlag(module, spine1, name, spine2, trunk_name1,
                               trunk_name2)

--- a/ansible/library/pn_l2_ztp_json.py
+++ b/ansible/library/pn_l2_ztp_json.py
@@ -354,9 +354,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                 node2 = system_names[node_count]
                 if node2 in non_clustered_leafs:
                     # Cluster creation
-                    cluster_name = node1 + '-to-' + node2 + '-cluster'
-                    if len(cluster_name) > 59:
-                        cluster_name = cluster_name[:59]
+                    cluster_name = (node1 + '-to-' + node2 + '-cluster')[:59]
 
                     output += create_cluster(module, node2, cluster_name,
                                              node1, node2)
@@ -371,9 +369,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                     output += trunk_message1[0] + '\n'
                     output += trunk_message2[0] + '\n'
                     # Vlag creation (leaf to spines)
-                    vlag_name = node1 + '-' + node2 + '-to-' + 'spine'
-                    if len(vlag_name) > 59:
-                        vlag_name = vlag_name[:59]
+                    vlag_name = (node1 + '-' + node2 + '-to-' + 'spine')[:59]
 
                     output += create_vlag(module, node1, vlag_name, node2,
                                           trunk_name1, trunk_name2)
@@ -391,9 +387,7 @@ def configure_trunk_vlag_for_clustered_leafs(module, non_clustered_leafs,
                     output += trunk_message2[0] + '\n'
 
                     # Vlag creation (spine to leafs)
-                    name =  'spine-to-' + node1 + '-' + node2
-                    if len(name) > 59:
-                        name = name[:59]
+                    name =  ('spine-to-' + node1 + '-' + node2)[:59]
 
                     output += create_vlag(module, spine1, name, spine2,
                                           trunk_name1, trunk_name2)
@@ -431,9 +425,7 @@ def configure_trunk_non_clustered_leafs(module, non_clustered_leafs,
         output += trunk_message2[0] + '\n'
 
         # Vlag creation (spine to leafs)
-        name = 'spine-to-' + leaf
-        if len(name) > 59:
-            name = name[:59]
+        name = ('spine-to-' + leaf)[:59]
 
         output += create_vlag(module, spine1, name, spine2, trunk_name1,
                               trunk_name2)

--- a/ansible/library/pn_ztp_vrrp_l3.py
+++ b/ansible/library/pn_ztp_vrrp_l3.py
@@ -414,7 +414,8 @@ def configure_vrrp_for_clustered_switches(module, vrrp_id, vrrp_ip,
     """
     node1 = switch_list[0]
     node2 = switch_list[1]
-    name = node1 + '-to-' + node2 + '-cluster'
+    name = (node1 + '-to-' + node2 + '-cluster')[:59]
+        
     host_count = 1
 
     output = create_cluster(module, node2, name, node1, node2)

--- a/ansible/library/pn_ztp_vrrp_l3_json.py
+++ b/ansible/library/pn_ztp_vrrp_l3_json.py
@@ -419,7 +419,7 @@ def configure_vrrp_for_clustered_switches(module, vrrp_id, vrrp_ip,
     """
     node1 = switch_list[0]
     node2 = switch_list[1]
-    name = node1 + '-to-' + node2 + '-cluster'
+    name = (node1 + '-to-' + node2 + '-cluster')[:59]
     host_count = 1
 
     output = create_cluster(module, node2, name, node1, node2)


### PR DESCRIPTION
## Summary:
**pn_l2_third_party.py:**
- changed cluster name and vlag name variables to accept at most 59 characters

**pn_l2_ztp.py:**
- changed cluster name and vlag name variables to accept at most 59 characters

**pn_l2_ztp_additional_switches.py:**
- changed cluster name and vlag name variables to accept at most 59 characters

**pn_l2_ztp_json.py:**
- changed cluster name and vlag name variable length checking to be more pythonic

**pn_ztp_vrrp_l3.py:**
- changed name variable to be at most 59 characters

**pn_ztp_vrrp_l3_json.py:**
- changed name variable to be at most 59 characters

## Notes
All I did here was modify all of the places I could find that did string length checking and simplified the code. I also added length checking in as many files that create clusters as possible. (Let me know if I missed any). This change should prevent any cluster name length errors.

Here is the python rule I am using, its somewhat niche but trust me it works:
```
>>> node1 = 'long-named-node-node-one'
>>> node2 = 'an-even-longer-named-node-,-node-two'
>>> cluster_name = (node1 + '-to-' + node2 + '-cluster')[:59]
>>> print cluster_name  
long-named-node-node-one-to-an-even-longer-named-node-,-nod
>>> 
>>> A = ('abc' + 'def')[:4]
>>> print A
abcd
>>> B = ('abc' + 'def')[:500]
>>> print B
abcdef
```

This works because the array limiter only limits when the string is longer than the index, otherwise it keeps its previous size. Meaning that we don't need to check for length and we can treat the string to the right of the assignment as an array and streamline the whole process.

Finally, in making this change I noticed that we are checking for the length multiple times per some files, is this a byproduct of an sensible quirk? Or can we consolidate them to remove redundancy?