### PR TITLE
[release-2.3] Remove Success from list of ports required for trunk creation in l2 ztp

### DIFF
--- a/ansible/library/pn_l2_ztp.py
+++ b/ansible/library/pn_l2_ztp.py
@@ -315,6 +315,7 @@ def configure_trunk(module, cluster_node, switch_list):
         switch_names += str(switch)
 
     src_ports = list(set(src_ports))
+    src_ports = filter(lambda l: l != 'Success', src_ports)
     name = cluster_node + '-to-' + switch_names
     if len(name) > 59:
         name = name[:59]


### PR DESCRIPTION
Sometimes, ports doesn't show up when we do `port-show` and `Success` gets returned in the list of ports that gets passed to `trunk-create`.
This fix will remove `Success` from the list of ports if present.