### PR TITLE
Removed ":" and "." from [dlink] The help/description for fabric name

### DIFF
--- a/ansible/playbooksConfiguration.xml
+++ b/ansible/playbooksConfiguration.xml
@@ -18,7 +18,7 @@
             <regex>^[a-zA-Z0-9_-]{1,59}$</regex>
             <parentKey>null</parentKey>
             <visible>true</visible>
-            <userAssistText>Can contain: "letters, numbers, _, ., :, and -"</userAssistText>
+            <userAssistText>Can contain: "letters, numbers, _, and -"</userAssistText>
         </guiProperties>
 
         <guiProperties>


### PR DESCRIPTION
Removed ":" and "." from [dlink] The help/description for fabric name